### PR TITLE
Fix: prevent .env from being used in production builds

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_VIRTUALDISPLAY_SERVER_HOST=http://localhost:4173/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules/
 dist/
 coverage/
 stats.html
-.env.local
+.env
 .env.act
 .idea/
 .npmrc

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,10 @@ import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
-export default defineConfig(() => {
+export default defineConfig(({ command }) => {
   return {
+    // Don't load any .env files during build
+    envFile: command === 'build' ? false : '.env',
     build: {
       outDir: 'dist',
       emptyOutDir: true,


### PR DESCRIPTION
## Summary
- Remove .env from git tracking and add to .gitignore
- Configure Vite to ignore .env files during build command
- Ensures production builds always use https://server.virtualdisplay.io

## Test plan
- [ ] Run `pnpm build` and verify no localhost references in dist files
- [ ] Verify .env is no longer tracked by git
- [ ] Confirm development mode still works with local .env file