### PR TITLE
Fix: change default logger level to warn

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,7 +2,7 @@ import { Logger } from '@virtualdisplay-io/logger';
 
 export const logger = Logger.getInstance().child({
   prefix: 'Client',
-  level: 'info', // Default level, can be changed via enableDebugMode
+  level: 'warn', // Show warnings and errors by default
 });
 
 export function enableDebugMode(): void {


### PR DESCRIPTION
## Summary
- Default logger level changed from 'info' to 'warn'
- Only warnings and errors are shown by default
- Info and debug messages only shown when debug: true is set

## Why
Reduces console noise in production environments while keeping important warnings visible.

## Test plan
- [ ] Run client without debug flag - should only see warnings/errors
- [ ] Run client with debug: true - should see all log levels
- [ ] Verify no breaking changes in functionality