### PR TITLE
fix: EventBus once handlers and logging improvements

### DIFF
--- a/src/client/iframe-builder.ts
+++ b/src/client/iframe-builder.ts
@@ -39,7 +39,6 @@ export class IframeBuilder {
     });
 
     // Apply attributes
-    iframe.setAttribute('allowfullscreen', 'true');
     iframe.setAttribute('allow', 'xr-spatial-tracking; fullscreen');
 
     iframe.addEventListener('load', () => {

--- a/src/events/event-bus.ts
+++ b/src/events/event-bus.ts
@@ -21,20 +21,42 @@ export class EventBus {
   }
 
   public emit<K extends keyof DomainEvents>(event: K, payload: DomainEvents[K]): void {
-    this.listeners.get(event)?.forEach(listener => listener(payload));
+    const handlers = this.listeners.get(event);
+
+    if (handlers === undefined || handlers.length === 0) {
+      return;
+    }
+
+    // Create a copy to avoid modification during iteration
+    // This is important for 'once' handlers that remove themselves
+    const handlersCopy = [...handlers];
+
+    handlersCopy.forEach((listener) => {
+      listener(payload);
+    });
   }
 
+  /**
+   * Register a listener that will be called only once
+   * The listener is automatically removed after the first call
+   */
   public once<K extends keyof DomainEvents>(
     event: K,
     listener: EventListener<DomainEvents[K]>,
   ): void {
     const onceWrapper: EventListener<DomainEvents[K]> = payload => {
+      // Remove this wrapper before calling the listener
+      // This ensures the listener is only called once
       this.off(event, onceWrapper);
       listener(payload);
     };
+
     this.on(event, onceWrapper);
   }
 
+  /**
+   * Remove a specific listener for an event
+   */
   public off<K extends keyof DomainEvents>(
     event: K,
     listener: EventListener<DomainEvents[K]>,

--- a/src/messaging/message-handler.ts
+++ b/src/messaging/message-handler.ts
@@ -27,17 +27,12 @@ export class MessageHandler {
 
   public setIframe(iframe: HTMLIFrameElement): void {
     this.iframe = iframe;
-    logger.debug('Message handler configured with iframe', {
-      src: iframe.src,
-      loaded: iframe.contentWindow !== null,
-    });
   }
 
   public destroy(): void {
     window.removeEventListener('message', this.handleWindowMessage);
     this.queue.length = 0;
     this.isReady = false;
-    logger.debug('Message handler destroyed');
   }
 
   private queueOrSend(message: Message): void {
@@ -68,7 +63,7 @@ export class MessageHandler {
     });
 
     this.iframe!.contentWindow!.postMessage(message, targetOrigin);
-    logger.info('Message sent to server', message);
+    logger.debug('Message sent to server', message);
   }
 
   private canSend(): boolean {
@@ -105,7 +100,6 @@ export class MessageHandler {
 
   private setupIncomingMessages(): void {
     window.addEventListener('message', this.handleWindowMessage);
-    logger.debug('Message handler started listening');
   }
 
   private setupOutgoingMessages(): void {

--- a/src/ui/virtualdisplay-viewer-service.ts
+++ b/src/ui/virtualdisplay-viewer-service.ts
@@ -41,7 +41,6 @@ export class VirtualdisplayViewerService {
 
     // Only send if we have any config to send
     if (Object.keys(config).length > 0) {
-      logger.debug('Sending initial UI configuration', config);
       this.sendUIConfig(config);
     }
   }
@@ -112,7 +111,6 @@ export class VirtualdisplayViewerService {
       config,
     };
 
-    logger.debug('Emitting CONFIG message', message);
     this.eventBus.emit(EVENT_NAMES.CONFIG_MESSAGE, { message });
   }
 }

--- a/test/unit/events/event-bus.test.ts
+++ b/test/unit/events/event-bus.test.ts
@@ -61,4 +61,23 @@ describe('EventBus', () => {
     expect(spy1).toHaveBeenCalled();
     expect(spy2).not.toHaveBeenCalled();
   });
+
+  it('should handle multiple once listeners that self-remove during execution', () => {
+    const bus = new EventBus();
+    const spy1 = vi.fn();
+    const spy2 = vi.fn();
+    const spy3 = vi.fn();
+
+    // This tests the bug we fixed - multiple once handlers where each removes itself
+    bus.once(EVENT_NAMES.IFRAME_READY, spy1);
+    bus.once(EVENT_NAMES.IFRAME_READY, spy2);
+    bus.once(EVENT_NAMES.IFRAME_READY, spy3);
+
+    // All handlers should be called despite self-removal during iteration
+    bus.emit(EVENT_NAMES.IFRAME_READY, {});
+
+    expect(spy1).toHaveBeenCalledTimes(1);
+    expect(spy2).toHaveBeenCalledTimes(1);
+    expect(spy3).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Fixed EventBus bug where multiple once handlers could interfere with each other
- Removed redundant iframe attribute
- Reduced logging verbosity

## Changes

### EventBus fix
Fixed an issue where multiple `once` event handlers could interfere with each other when they self-remove during execution. Now creates a copy of the handlers array before iteration.

### Iframe cleanup
Removed duplicate `allowfullscreen="true"` attribute as it's already covered by the `allow="fullscreen"` attribute.

### Logging improvements
Reduced logging verbosity by:
- Removing unnecessary debug logs
- Changing message sent log from info to debug level
- Removing duplicate debug logs

## Test Plan
- [x] Added test for EventBus once handler fix
- [x] All existing tests pass
- [x] Manual testing shows reduced log output